### PR TITLE
Swap 'sizeof' by 'strlen' in the request and response examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Examples
         Request request;
         HttpRequestParser parser;
     
-        HttpRequestParser::ParseResult res = parser.parse(request, text, text + sizeof(text));
+        HttpRequestParser::ParseResult res = parser.parse(request, text, text + strlen(text));
     
         if( res == HttpRequestParser::ParsingCompleted )
         {
@@ -61,7 +61,7 @@ Examples
         Response response;
         HttpResponseParser parser;
     
-        HttpResponseParser::ParseResult res = parser.parse(response, text, text + sizeof(text));
+        HttpResponseParser::ParseResult res = parser.parse(response, text, text + strlen(text));
     
         if( res == HttpResponseParser::ParsingCompleted )
         {


### PR DESCRIPTION
Fixes the request and response examples. As it stands, a '\0' character is being unnecessarily added to the parser, this caused messages cut in the middle of the headers to be treated as an error.

This probably solves this problem: #1 