### PR TITLE
clear request/response parser state before starting

### DIFF
--- a/src/httpparser/httprequestparser.h
+++ b/src/httpparser/httprequestparser.h
@@ -45,6 +45,7 @@ private:
 
     ParseResult consume(Request &req, const char *begin, const char *end)
     {
+        state = RequestMethodStart;
         while( begin != end )
         {
             char input = *begin++;

--- a/src/httpparser/httpresponseparser.h
+++ b/src/httpparser/httpresponseparser.h
@@ -46,6 +46,7 @@ private:
 
     ParseResult consume(Response &resp, const char *begin, const char *end)
     {
+        state = ResponseStatusStart;
         while( begin != end )
         {
             char input = *begin++;


### PR DESCRIPTION
Currently, the parser retains the parser state, so no matter how many times you call consume, it will always start with the last state of the first call